### PR TITLE
Apply Null Coalescing Assignment Operator

### DIFF
--- a/src/ConsecutiveArguments.php
+++ b/src/ConsecutiveArguments.php
@@ -42,7 +42,7 @@ final class ConsecutiveArguments
 
             /** @var mixed $argument */
             foreach ($arguments as $position => $argument) {
-                $argumentsGroupedByPosition[$position] = $argumentsGroupedByPosition[$position] ?? [];
+                $argumentsGroupedByPosition[$position] ??= [];
                 $argumentsGroupedByPosition[$position][] = $argument;
             }
         }


### PR DESCRIPTION
# Changed log

- According to the [reference](https://wiki.php.net/rfc/null_coalesce_equal_operator), using the shortened null equal operator to make code readable for the self assignment. 