### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+*.xml  export-ignore
+.github/ export-ignore
+.php-cs-fixer.dist.php export-ignore
+composerw export-ignore
+Dockerfile export-ignore
+rector.php export-ignore
+rector-test/ export-ignore
+tests/ export-ignore


### PR DESCRIPTION
[`.gitattributes`](https://git-scm.com/docs/gitattributes) can excludes files that don't need to be distributed with Composer.

Files to be archived can be checked using `git archive HEAD | tar -t`

```
$ git archive main | tar -t
.github/
.github/dependabot.yml
.github/workflows/
.github/workflows/ci.yml
.gitignore
.php-cs-fixer.dist.php
CONTRIBUTE.md
Dockerfile
LICENSE.md
README.md
composer.json
composer.lock
composerw
phpunit.xml
psalm-baseline.xml
psalm.xml
rector-test/
rector-test/ExampleTest.php
rector.php
src/
src/ConsecutiveArguments.php
src/ConsecutiveArgumentsRectorRule.php
tests/
tests/ConsecutiveArgumentsTest.php
tests/Stub/
tests/Stub/MockableConsecutiveArgumentInterface.php

$ git archive add/gitattributes | tar -t
.gitattributes
.gitignore
CONTRIBUTE.md
LICENSE.md
README.md
composer.json
composer.lock
src/
src/ConsecutiveArguments.php
src/ConsecutiveArgumentsRectorRule.php
```