### PR TITLE
Document PHPUnit 13 built‑in consecutive argument methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ composer require michaelpetri/phpunit-consecutive-arguments
 ```
 
 See [Tests](tests/ConsecutiveArgumentsTest.php) for more examples
+
+## PHPUnit version notes
+
+- PHPUnit 10–12: [`withConsecutive()` was removed](https://github.com/sebastianbergmann/phpunit/issues/5063), so this library provides a drop-in replacement (see the [PHPUnit 9.6 deprecations note](https://github.com/sebastianbergmann/phpunit/blob/9.6/DEPRECATIONS.md)).
+- PHPUnit 13+: PHPUnit ships a native alternative [`withParameterSetsInOrder()`](https://github.com/sebastianbergmann/phpunit-documentation-english/issues/405), announced in [PHPUnit 13.0](https://phpunit.de/announcements/phpunit-13.html).
+
+If you only target PHPUnit 13 or newer, use the built-in methods. This package stays useful when you need one codebase that runs on both PHPUnit 10–12 and 13+.


### PR DESCRIPTION
[PHPUnit 13](https://phpunit.de/announcements/phpunit-13.html) now provides [`withParameterSetsInOrder()`](https://github.com/sebastianbergmann/phpunit-documentation-english/issues/405), so users on 13+ can rely on the built-ins.

```diff
 $mock
     ->expects(self::exactly(2))
     ->method('someMethod')
-    ->with(
-        ...ConsecutiveArguments::of(
+    ->withParameterSetsInOrder(
         ['1.1', '1.2'],
         ['2.1', '2.2'],
-        )
     );
```

This update adds a README note explaining when those native methods are preferred and when this package remains useful for projects that must also support PHPUnit 10–12.